### PR TITLE
Add backend tests and CI workflow

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,32 @@
+name: Backend Tests
+
+on:
+  push:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+  pull_request:
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-tests.yml'
+
+jobs:
+  test-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r backend/requirements.txt
+          python -m pip install pytest flake8
+      - name: Lint
+        run: |
+          PYTHONPATH=backend python -m flake8 backend/tests
+      - name: Test
+        run: |
+          PYTHONPATH=backend pytest backend/tests -q

--- a/backend/tests/test_system.py
+++ b/backend/tests/test_system.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+def test_health(client):
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "healthy"
+    assert "llm_connected" in data
+
+
+def test_supported_formats(client):
+    response = client.get("/api/config/supported-formats")
+    assert response.status_code == 200
+    data = response.json()
+    assert ".pdf" in data["supported_extensions"]
+
+
+def test_list_items(client):
+    response = client.get("/api/items")
+    assert response.status_code == 200
+    data = response.json()
+    assert any(item["name"] == "Document Processing" for item in data)


### PR DESCRIPTION
## Summary
- add FastAPI system endpoint tests for health, config, and list items
- configure GitHub Actions to run backend linting and tests

## Testing
- `PYTHONPATH=backend python -m flake8 backend/tests`
- `PYTHONPATH=backend pytest backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_b_68b0a655d5b48333ba6c26c793878bc8